### PR TITLE
Default to the public API.

### DIFF
--- a/lib/dia.js
+++ b/lib/dia.js
@@ -33,6 +33,8 @@ if (userConfig.data && userConfig.data.api_uri) {
   } else {
     librarian.init(durl.hostname, durl.port || 80, false);
   }
+} else {
+  librarian.init('api.onmodulus.net', 443, true);
 }
 
 var validators = require('./validators')(dia);

--- a/lib/dia.js
+++ b/lib/dia.js
@@ -198,9 +198,6 @@ dia.authenticate = function (username, password, fn) {
 //    Modulus to be created.
 //
 dia.create = function (filename, user) {
-  if (!userConfig.data) {
-    return console.log('\n  you must configured the API endpoint\n'.fail);
-  }
   if (!user.flags.isProvider) {
     return console.log('\n  you must opt into the Modulus provider program\n'.fail);
   }


### PR DESCRIPTION
If the `api_uri` configuration option is not set, default to the public API.
