### PR TITLE
Updated to use the correct flag.

### DIFF
--- a/lib/dia.js
+++ b/lib/dia.js
@@ -202,7 +202,7 @@ dia.create = function (filename, user) {
   if (!user.flags.isProvider) {
     return console.log('\n  you must opt into the Modulus provider program\n'.fail);
   }
-  if (!user.flags.isVerified) {
+  if (!user.flags.isVerifiedProvider) {
     return console.log('\n  you must be verified to create an add-on\n'.fail);
   }
 


### PR DESCRIPTION
Use `isVerifiedProvider` for verifying that account information is present before creating a new add-on.
